### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "ruby"
+run = ""

--- a/README.rdoc
+++ b/README.rdoc
@@ -22,7 +22,7 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
-
+[![Run on Repl.it](https://repl.it/badge/github/tylerryan307/riblog)](https://repl.it/github/tylerryan307/riblog)
 
 Please feel free to use a different markup language if you do not plan to run
 <tt>rake doc:app</tt>.


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).